### PR TITLE
feat: callbacks with parsers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sklearn-smithy"
-version = "0.0.4"
+version = "0.0.5"
 
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/sksmithy/__main__.py
+++ b/sksmithy/__main__.py
@@ -62,7 +62,6 @@ def forge(
 
     * in which file the class should be saved (default is `f'{name.lower()}.py'`)
     """
-    print(f"{estimator_type=}")
     forged_template = render_template(
         name=name,
         estimator_type=estimator_type,

--- a/sksmithy/__main__.py
+++ b/sksmithy/__main__.py
@@ -3,16 +3,18 @@ from pathlib import Path
 import typer
 
 from sksmithy._arguments import (
+    decision_function_arg,
     estimator_type_arg,
+    linear_arg,
     name_arg,
     optional_params_arg,
+    output_file_arg,
+    predict_proba_arg,
     required_params_arg,
     sample_weight_arg,
+    tags_arg,
 )
 from sksmithy._logger import console
-from sksmithy._models import EstimatorType
-from sksmithy._parsers import tags_parser
-from sksmithy._prompts import PROMPT_DECISION_FUNCTION, PROMPT_LINEAR, PROMPT_OUTPUT, PROMPT_PREDICT_PROBA, PROMPT_TAGS
 from sksmithy._utils import render_template
 
 app = typer.Typer(
@@ -37,6 +39,11 @@ def forge(
     required_params: required_params_arg = "",
     optional_params: optional_params_arg = "",
     sample_weight: sample_weight_arg = False,
+    linear: linear_arg = False,
+    predict_proba: predict_proba_arg = False,
+    decision_function: decision_function_arg = False,
+    tags: tags_arg = "",
+    output_file: output_file_arg = "",
 ) -> None:
     """Asks a list of questions to generate a shiny new estimator ✨
 
@@ -55,44 +62,17 @@ def forge(
 
     * in which file the class should be saved (default is `f'{name.lower()}.py'`)
     """
-    # Check if linear
-    match estimator_type:
-        case EstimatorType.ClassifierMixin | EstimatorType.RegressorMixin:
-            linear = typer.confirm(PROMPT_LINEAR)
-        case _:
-            linear = False
-
-    # Check if supports predict_proba
-    match estimator_type:
-        case EstimatorType.ClassifierMixin | EstimatorType.OutlierMixin:
-            predict_proba = typer.confirm(PROMPT_PREDICT_PROBA)
-        case _:
-            predict_proba = False
-
-    # Check if supports decision_function
-    match estimator_type:
-        case EstimatorType.ClassifierMixin:
-            decision_function = typer.confirm(PROMPT_DECISION_FUNCTION)
-        case _:
-            decision_function = False
-
-    tags = typer.prompt(PROMPT_TAGS, default="")
-    tags, msg = tags_parser(tags)
-    if msg:
-        raise typer.BadParameter(msg)
-
-    output_file = typer.prompt(PROMPT_OUTPUT, default=f"{name.lower()}.py")
-
+    print(f"{estimator_type=}")
     forged_template = render_template(
         name=name,
         estimator_type=estimator_type,
-        required=required_params,  # type: ignore[arg-type]  # Callback actually transforms those into list[str]
-        optional=optional_params,  # type: ignore[arg-type]  # Callback actually transforms those into list[str]
+        required=required_params,  # type: ignore[arg-type]  # Callback actually transforms it into `list[str]`
+        optional=optional_params,  # type: ignore[arg-type]  # Callback actually transforms it into `list[str]`
         linear=linear,
         sample_weight=sample_weight,
         predict_proba=predict_proba,
         decision_function=decision_function,
-        tags=tags,
+        tags=tags,  # type: ignore[arg-type]  # Callback actually transforms it into `list[str]`
     )
 
     destination_file = Path(output_file)

--- a/sksmithy/__main__.py
+++ b/sksmithy/__main__.py
@@ -86,8 +86,8 @@ def forge(
     forged_template = render_template(
         name=name,
         estimator_type=estimator_type,
-        required=required_params,
-        optional=optional_params,
+        required=required_params,  # type: ignore[arg-type]  # Callback actually transforms those into list[str]
+        optional=optional_params,  # type: ignore[arg-type]  # Callback actually transforms those into list[str]
         linear=linear,
         sample_weight=sample_weight,
         predict_proba=predict_proba,

--- a/sksmithy/_arguments.py
+++ b/sksmithy/_arguments.py
@@ -2,14 +2,19 @@ from typing import Annotated
 
 from typer import Option
 
-from sksmithy._callbacks import name_callback, params_callback
+from sksmithy._callbacks import estimator_callback, name_callback, params_callback, tags_callback
 from sksmithy._models import EstimatorType
 from sksmithy._prompts import (
+    PROMPT_DECISION_FUNCTION,
     PROMPT_ESTIMATOR,
+    PROMPT_LINEAR,
     PROMPT_NAME,
     PROMPT_OPTIONAL,
+    PROMPT_OUTPUT,
+    PROMPT_PREDICT_PROBA,
     PROMPT_REQUIRED,
     PROMPT_SAMPLE_WEIGHT,
+    PROMPT_TAGS,
 )
 
 name_arg = Annotated[
@@ -26,6 +31,7 @@ estimator_type_arg = Annotated[
     Option(
         prompt=PROMPT_ESTIMATOR,
         help="Estimator type.",
+        callback=estimator_callback,
     ),
 ]
 
@@ -51,6 +57,58 @@ sample_weight_arg = Annotated[
     bool,
     Option(
         prompt=PROMPT_SAMPLE_WEIGHT,
+        is_flag=True,
         help="Whether or not `.fit()` does support [bold green]`sample_weight`[/bold green].",
+    ),
+]
+
+linear_arg = Annotated[
+    bool,
+    Option(
+        is_flag=True,
+        prompt=PROMPT_LINEAR,
+        help="Whether or not the estimator is [bold green]linear[/bold green].",
+    ),
+]
+
+predict_proba_arg = Annotated[
+    bool,
+    Option(
+        is_flag=True,
+        prompt=PROMPT_PREDICT_PROBA,
+        help="Whether or not the estimator implements [bold green]`predict_proba`[/bold green] method.",
+    ),
+]
+
+decision_function_arg = Annotated[
+    bool,
+    Option(
+        is_flag=True,
+        prompt=PROMPT_DECISION_FUNCTION,
+        help="Whether or not the estimator implements [bold green]`decision_function`[/bold green] method.",
+    ),
+]
+
+tags_arg = Annotated[
+    str,
+    Option(
+        prompt=PROMPT_TAGS,
+        help="List of optional scikit-learn [bold green]tags[/bold green].",
+        callback=tags_callback,
+    ),
+]
+
+
+def callback(ctx, param, value):
+    print("here")
+    return value
+
+
+output_file_arg = Annotated[
+    str,
+    Option(
+        prompt=PROMPT_OUTPUT,
+        help="[bold green]Destination file[/bold green] where to save the boilerplate code.",
+        callback=callback,
     ),
 ]

--- a/sksmithy/_arguments.py
+++ b/sksmithy/_arguments.py
@@ -21,6 +21,7 @@ name_arg = Annotated[
     str,
     Option(
         prompt=PROMPT_NAME,
+        prompt_required=False,
         help="[bold green]Name[/bold green] the estimator.",
         callback=name_callback,
     ),
@@ -30,6 +31,7 @@ estimator_type_arg = Annotated[
     EstimatorType,
     Option(
         prompt=PROMPT_ESTIMATOR,
+        prompt_required=False,
         help="Estimator type.",
         callback=estimator_callback,
     ),
@@ -56,8 +58,9 @@ optional_params_arg = Annotated[
 sample_weight_arg = Annotated[
     bool,
     Option(
-        prompt=PROMPT_SAMPLE_WEIGHT,
         is_flag=True,
+        prompt=PROMPT_SAMPLE_WEIGHT,
+        prompt_required=False,
         help="Whether or not `.fit()` does support [bold green]`sample_weight`[/bold green].",
     ),
 ]
@@ -93,22 +96,16 @@ tags_arg = Annotated[
     str,
     Option(
         prompt=PROMPT_TAGS,
+        prompt_required=False,
         help="List of optional scikit-learn [bold green]tags[/bold green].",
         callback=tags_callback,
     ),
 ]
-
-
-def callback(ctx, param, value):
-    print("here")
-    return value
-
 
 output_file_arg = Annotated[
     str,
     Option(
         prompt=PROMPT_OUTPUT,
         help="[bold green]Destination file[/bold green] where to save the boilerplate code.",
-        callback=callback,
     ),
 ]

--- a/sksmithy/_arguments.py
+++ b/sksmithy/_arguments.py
@@ -2,9 +2,15 @@ from typing import Annotated
 
 from typer import Option
 
-from sksmithy._callbacks import args_callback, name_callback
+from sksmithy._callbacks import name_callback, params_callback
 from sksmithy._models import EstimatorType
-from sksmithy._prompts import PROMPT_ESTIMATOR, PROMPT_NAME, PROMPT_OPTIONAL, PROMPT_REQUIRED, PROMPT_SAMPLE_WEIGHT
+from sksmithy._prompts import (
+    PROMPT_ESTIMATOR,
+    PROMPT_NAME,
+    PROMPT_OPTIONAL,
+    PROMPT_REQUIRED,
+    PROMPT_SAMPLE_WEIGHT,
+)
 
 name_arg = Annotated[
     str,
@@ -28,15 +34,16 @@ required_params_arg = Annotated[
     Option(
         prompt=PROMPT_REQUIRED,
         help="List of [bold green]required[/bold green] parameters (comma-separated).",
-        callback=args_callback,
+        callback=params_callback,
     ),
 ]
+
 optional_params_arg = Annotated[
     str,
     Option(
         prompt=PROMPT_OPTIONAL,
         help="List of [bold green]optional[/bold green] parameters (comma-separated).",
-        callback=args_callback,
+        callback=params_callback,
     ),
 ]
 

--- a/sksmithy/_callbacks.py
+++ b/sksmithy/_callbacks.py
@@ -3,7 +3,9 @@ from typing import Concatenate, ParamSpec, TypeVar
 
 from typer import BadParameter, CallbackParam, Context
 
+from sksmithy._models import EstimatorType
 from sksmithy._parsers import check_duplicates, name_parser, params_parser, tags_parser
+from sksmithy._prompts import PROMPT_DECISION_FUNCTION, PROMPT_LINEAR, PROMPT_PREDICT_PROBA
 
 T = TypeVar("T")
 R = TypeVar("R")
@@ -38,10 +40,14 @@ def name_callback(ctx: Context, param: CallbackParam, value: str) -> str:
     """`name` argument callback."""
     *_, name = _parse_wrapper(ctx, param, value, name_parser)
 
+    all_options = ctx.command.params
+    output_file_option = next(opt for opt in all_options if opt.name == "output_file")
+    output_file_option.default = f"{name.lower()}.py"
+
     return name
 
 
-def params_callback(ctx: Context, param: CallbackParam, value: str | None) -> list[str]:
+def params_callback(ctx: Context, param: CallbackParam, value: str) -> list[str]:
     """`required-params` and `optional-params` arguments callback."""
     ctx, param, parsed_params = _parse_wrapper(ctx, param, value, params_parser)
 
@@ -61,3 +67,48 @@ def tags_callback(ctx: Context, param: CallbackParam, value: str) -> list[str]:
     """`tags` argument callback."""
     *_, parsed_value = _parse_wrapper(ctx, param, value, tags_parser)
     return parsed_value
+
+
+def estimator_callback(ctx: Context, param: CallbackParam, value: EstimatorType) -> EstimatorType:
+    """`estimator_type` argument callback.
+
+    It dynamically modifies the behaviour of the rest of the prompts based on its value.
+    """
+    if not ctx.obj:
+        ctx.obj = {}
+
+    if param.name in ctx.obj:
+        return ctx, param, ctx.obj[param.name]
+
+    linear, predict_proba, decision_function = (
+        op for op in ctx.command.params if op.name in {"linear", "predict_proba", "decision_function"}
+    )
+
+    match value:
+        case EstimatorType.ClassifierMixin | EstimatorType.RegressorMixin:
+            linear.prompt = PROMPT_LINEAR
+            linear.prompt_required = True
+        case _:
+            linear.prompt = False
+            linear.prompt_required = False
+
+    match value:
+        case EstimatorType.ClassifierMixin | EstimatorType.OutlierMixin:
+            predict_proba.prompt = PROMPT_PREDICT_PROBA
+            predict_proba.prompt_required = True
+        case _:
+            predict_proba.prompt = False
+            predict_proba.prompt_required = False
+
+    # Check if supports decision_function
+    match value:
+        case EstimatorType.ClassifierMixin:
+            decision_function.prompt = PROMPT_DECISION_FUNCTION
+            decision_function.prompt_required = True
+        case _:
+            decision_function.prompt = False
+            decision_function.prompt_required = False
+
+    ctx.obj[param.name] = value
+
+    return value

--- a/sksmithy/_callbacks.py
+++ b/sksmithy/_callbacks.py
@@ -5,7 +5,6 @@ from typer import BadParameter, CallbackParam, Context
 
 from sksmithy._models import EstimatorType
 from sksmithy._parsers import check_duplicates, name_parser, params_parser, tags_parser
-from sksmithy._prompts import PROMPT_DECISION_FUNCTION, PROMPT_LINEAR, PROMPT_PREDICT_PROBA
 
 T = TypeVar("T")
 R = TypeVar("R")
@@ -69,7 +68,7 @@ def tags_callback(ctx: Context, param: CallbackParam, value: str) -> list[str]:
     return parsed_value
 
 
-def estimator_callback(ctx: Context, param: CallbackParam, value: EstimatorType) -> EstimatorType:
+def estimator_callback(ctx: Context, param: CallbackParam, estimator: EstimatorType) -> str:
     """`estimator_type` argument callback.
 
     It dynamically modifies the behaviour of the rest of the prompts based on its value.
@@ -78,37 +77,33 @@ def estimator_callback(ctx: Context, param: CallbackParam, value: EstimatorType)
         ctx.obj = {}
 
     if param.name in ctx.obj:
-        return ctx, param, ctx.obj[param.name]
+        return ctx.obj[param.name]
 
     linear, predict_proba, decision_function = (
         op for op in ctx.command.params if op.name in {"linear", "predict_proba", "decision_function"}
     )
 
-    match value:
+    match estimator:
         case EstimatorType.ClassifierMixin | EstimatorType.RegressorMixin:
-            linear.prompt = PROMPT_LINEAR
-            linear.prompt_required = True
+            pass
         case _:
-            linear.prompt = False
-            linear.prompt_required = False
+            linear.prompt = False  # type: ignore[attr-defined]
+            linear.prompt_required = False  # type: ignore[attr-defined]
 
-    match value:
+    match estimator:
         case EstimatorType.ClassifierMixin | EstimatorType.OutlierMixin:
-            predict_proba.prompt = PROMPT_PREDICT_PROBA
-            predict_proba.prompt_required = True
+            pass
         case _:
-            predict_proba.prompt = False
-            predict_proba.prompt_required = False
+            predict_proba.prompt = False  # type: ignore[attr-defined]
+            predict_proba.prompt_required = False  # type: ignore[attr-defined]
 
-    # Check if supports decision_function
-    match value:
+    match estimator:
         case EstimatorType.ClassifierMixin:
-            decision_function.prompt = PROMPT_DECISION_FUNCTION
-            decision_function.prompt_required = True
+            pass
         case _:
-            decision_function.prompt = False
-            decision_function.prompt_required = False
+            decision_function.prompt = False  # type: ignore[attr-defined]
+            decision_function.prompt_required = False  # type: ignore[attr-defined]
 
-    ctx.obj[param.name] = value
+    ctx.obj[param.name] = estimator.value
 
-    return value
+    return estimator.value

--- a/sksmithy/_parsers.py
+++ b/sksmithy/_parsers.py
@@ -1,0 +1,57 @@
+from keyword import iskeyword
+
+from sksmithy._models import TagType
+
+
+def name_parser(name: str) -> tuple[str, str]:
+    """Validate that `name` is a valid python class name."""
+    is_valid = name.isidentifier()
+    msg = f"`{name}` is not a valid python class name!" if not is_valid else ""
+
+    is_kw = iskeyword(name)
+    msg = f"`{name}` is a python reserved keyword!" if is_kw else ""
+
+    return name, msg
+
+
+def params_parser(params: str | None) -> tuple[list[str], str]:
+    """Parse and validate that `params` contains valid python names."""
+    if params:
+        param_list = params.split(",")
+        invalid = tuple(p for p in param_list if not p.isidentifier())
+
+        if len(invalid) > 0:
+            msg = f"The following parameters are invalid python identifiers: {invalid}"
+            return [], msg
+
+        if len(set(param_list)) < len(param_list):
+            msg = "Found repeated parameter."
+            return [], msg
+
+        return param_list, ""
+    return [], ""
+
+
+def check_duplicates(required: list[str], optional: list[str]) -> str:
+    """Check that there are not duplicates between required and optional params."""
+    duplicated_params = set(required).intersection(set(optional))
+
+    return f"The following parameters are duplicated: {duplicated_params}" if duplicated_params else ""
+
+
+def tags_parser(tags: str) -> list[str]:
+    """Parse and validate `tags` by comparing with sklearn list."""
+    if tags:
+        list_tag = tags.split(",")
+        unavailable_tags = tuple(t for t in list_tag if t not in TagType.__members__)
+        msg = (
+            (
+                f"The following tags are not available: {unavailable_tags}."
+                "\nPlease check the documentation at https://scikit-learn.org/dev/developers/develop.html#estimator-tags"
+                " to know which values are available."
+            )
+            if len(unavailable_tags)
+            else ""
+        )
+        return list_tag, msg
+    return [], ""

--- a/sksmithy/_parsers.py
+++ b/sksmithy/_parsers.py
@@ -3,15 +3,17 @@ from keyword import iskeyword
 from sksmithy._models import TagType
 
 
-def name_parser(name: str) -> tuple[str, str]:
+def name_parser(name: str | None) -> tuple[str, str]:
     """Validate that `name` is a valid python class name."""
-    is_valid = name.isidentifier()
-    msg = f"`{name}` is not a valid python class name!" if not is_valid else ""
+    if name:
+        is_valid = name.isidentifier()
+        msg = f"`{name}` is not a valid python class name!" if not is_valid else ""
 
-    is_kw = iskeyword(name)
-    msg = f"`{name}` is a python reserved keyword!" if is_kw else ""
+        is_kw = iskeyword(name)
+        msg = f"`{name}` is a python reserved keyword!" if is_kw else ""
 
-    return name, msg
+        return name, msg
+    return "", "Name cannot be empty!"
 
 
 def params_parser(params: str | None) -> tuple[list[str], str]:
@@ -25,7 +27,7 @@ def params_parser(params: str | None) -> tuple[list[str], str]:
             return [], msg
 
         if len(set(param_list)) < len(param_list):
-            msg = "Found repeated parameter."
+            msg = "Found repeated parameters!"
             return [], msg
 
         return param_list, ""
@@ -39,7 +41,7 @@ def check_duplicates(required: list[str], optional: list[str]) -> str:
     return f"The following parameters are duplicated: {duplicated_params}" if duplicated_params else ""
 
 
-def tags_parser(tags: str) -> list[str]:
+def tags_parser(tags: str) -> tuple[list[str], str]:
     """Parse and validate `tags` by comparing with sklearn list."""
     if tags:
         list_tag = tags.split(",")

--- a/sksmithy/_parsers.py
+++ b/sksmithy/_parsers.py
@@ -7,10 +7,15 @@ def name_parser(name: str | None) -> tuple[str, str]:
     """Validate that `name` is a valid python class name."""
     if name:
         is_valid = name.isidentifier()
-        msg = f"`{name}` is not a valid python class name!" if not is_valid else ""
-
         is_kw = iskeyword(name)
-        msg = f"`{name}` is a python reserved keyword!" if is_kw else ""
+
+        msg = (
+            f"`{name}` is not a valid python class name!"
+            if not is_valid
+            else f"`{name}` is a python reserved keyword!"
+            if is_kw
+            else ""
+        )
 
         return name, msg
     return "", "Name cannot be empty!"

--- a/sksmithy/_prompts.py
+++ b/sksmithy/_prompts.py
@@ -7,8 +7,8 @@ PROMPT_OPTIONAL: Final[str] = "📑 Please list the optional parameters (comma-s
 PROMPT_SAMPLE_WEIGHT: Final[str] = "📶 Does the `.fit()` method support `sample_weight`?"
 
 PROMPT_LINEAR: Final[str] = "📏 Is the estimator linear?"
-PROMPT_PREDICT_PROBA: Final[str] = "🎲 Should the estimator have a `predict_proba` method?"
-PROMPT_DECISION_FUNCTION: Final[str] = "❓ Should the estimator have a `decision_function` method?"
+PROMPT_PREDICT_PROBA: Final[str] = "🎲 Should the estimator implement a `predict_proba` method?"
+PROMPT_DECISION_FUNCTION: Final[str] = "❓ Should the estimator implement a `decision_function` method?"
 PROMPT_TAGS: Final[str] = (
     "🧪 We are almost there... Is there any tag you want to add? (comma or space separated)\n"
     "To know more about tags, check the documentation at:\n"

--- a/sksmithy/_prompts.py
+++ b/sksmithy/_prompts.py
@@ -3,14 +3,14 @@ from typing import Final
 PROMPT_NAME: Final[str] = "🐍 How would you like to name the estimator?"
 PROMPT_ESTIMATOR: Final[str] = "🎯 Which kind of estimator is it?"
 PROMPT_REQUIRED: Final[str] = "📜 Please list the required parameters (comma-separated)"
-PROMPT_OPTIONAL: Final[str] = "📑 Please list the optional parameters (comma separated)"
+PROMPT_OPTIONAL: Final[str] = "📑 Please list the optional parameters (comma-separated)"
 PROMPT_SAMPLE_WEIGHT: Final[str] = "📶 Does the `.fit()` method support `sample_weight`?"
 
 PROMPT_LINEAR: Final[str] = "📏 Is the estimator linear?"
 PROMPT_PREDICT_PROBA: Final[str] = "🎲 Should the estimator have a `predict_proba` method?"
 PROMPT_DECISION_FUNCTION: Final[str] = "❓ Should the estimator have a `decision_function` method?"
 PROMPT_TAGS: Final[str] = (
-    "🧪 We are almost there... Are there any tag you want to add? (comma or space separated)\n"
+    "🧪 We are almost there... Is there any tag you want to add? (comma or space separated)\n"
     "To know more about tags, check the documentation at:\n"
     "https://scikit-learn.org/dev/developers/develop.html#estimator-tags"
 )

--- a/sksmithy/_utils.py
+++ b/sksmithy/_utils.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 
 from sksmithy._models import EstimatorType
 
-TEMPLATE_PATH: Final[Path] = resources.files("sksmithy") / "template.py.jinja"  # type: ignore[assignment]
+TEMPLATE_PATH: Final[Path] = Path(str(resources.files("sksmithy") / "template.py.jinja"))
 
 
 def render_template(

--- a/sksmithy/app.py
+++ b/sksmithy/app.py
@@ -67,7 +67,7 @@ with st.sidebar:
         pytest compatible decorator.
     """)
 
-estimator_type = None
+
 sample_weights = False
 linear = False
 predict_proba = False
@@ -107,6 +107,7 @@ with st.container():  # name and type
 
         if estimator:
             estimator_type = EstimatorType(estimator)
+
 
 with st.container():  # params
     c21, c22 = st.columns(2)
@@ -194,7 +195,7 @@ with st.container():  # forge button
                 [
                     not name,
                     msg_invalid_name,
-                    estimator_type is None,
+                    estimator is None,
                     msg_invalid_required,
                     msg_duplicated_params,
                 ]


### PR DESCRIPTION
# Description

Name may be a bit misleading as cli arguments didn't move to parsers. However:

- callbacks now call parses, which means that parsers are re-usable in the app
- callbacks dynamically update other arguments flags, prompts, and if they fire or not

Fix #10
